### PR TITLE
coerce data in sse stream to bytes

### DIFF
--- a/flask_sse.py
+++ b/flask_sse.py
@@ -36,13 +36,13 @@ class SseStream(object):
     def __iter__(self):
         sse = PySse()
         for data in sse:
-            yield data
+            yield str(data)
         for message in self.pubsub.listen():
             if message['type'] == 'message':
                 event, data = json.loads(message['data'])
                 sse.add_message(event, data)
                 for data in sse:
-                    yield data
+                    yield str(data)
         
 
 sse = Blueprint('sse', __name__)


### PR DESCRIPTION
Hello! Werkzeug falls with **AssertionError 'applications must write bytes'** because of unicode strings like **u'retry: 30000\n'** coming from sse. Coercion to str should fix the problem.
