### PR TITLE
fix typo in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ Clients can subscribe to different channels by setting 'channel' on the query st
     
     #######
         
-    var source = new EventSource("{{ url_for('sse.stream'), channel='logs' }}")    
+    var source = new EventSource("{{ url_for('sse.stream', channel='logs') }}")    
     
 Being a blueprint, you can attach a before_request handler to handle things like access control:
 


### PR DESCRIPTION
channel argument was outside of url_for function call.
